### PR TITLE
PHP Strict Standards fix

### DIFF
--- a/RestDAO.php
+++ b/RestDAO.php
@@ -188,7 +188,7 @@ class RestUser extends User {
         parent::__construct();
     }
 
-    public function findByPrimaryKey($userId = NULL) {
+    public function findUserByPrimaryKey($userId = NULL) {
         $this->dao->select("*");
         $this->setPrimaryKey('pk_i_id');
         $this->dao->from(DB_TABLE_PREFIX . 't_user');


### PR DESCRIPTION
PHP Strict Standards:  Declaration of RestUser::findByPrimaryKey() should be compatible with DAO::findByPrimaryKey($value)
